### PR TITLE
Update to support latest Grunt TSLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-teamcity-reporter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A TSLint formatter/reporter for use in TeamCity which groups by files using TeamCity Test Suite",
   "main": "index.js",
   "scripts": {
@@ -26,11 +26,10 @@
   },
   "homepage": "https://github.com/ThaNarie/tslint-teamcity-reporter",
   "devDependencies": {
-	  "grunt-cli": "0.1.9",
-	  "grunt": "~0.4.1",
-	  "grunt-tslint": "~0.4.0",
+	  "grunt-cli": "~0.1.13",
+	  "grunt": "~0.4.5",
+	  "grunt-tslint": "~3.0.1",
 	  "grunt-contrib-jshint": "0.6.4",
-	  "tslint-teamcity-reporter": "0.1.4",
 	  "grunt-run-grunt": "~0.1.0",
 	  "grunt-mocha-test": "~0.7.0",
 	  "grunt-contrib-clean": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-teamcity-reporter",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "A TSLint formatter/reporter for use in TeamCity which groups by files using TeamCity Test Suite",
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,9 @@
     "url": "https://github.com/ThaNarie/tslint-teamcity-reporter/issues"
   },
   "homepage": "https://github.com/ThaNarie/tslint-teamcity-reporter",
+  "peerDependencies": {
+	"tslint": "^3.0.0 || >=3.0.0-dev || >=3.1.0-dev || >=3.2.0-dev || >=3.3.0-dev"
+  },
   "devDependencies": {
 	  "grunt-cli": "~0.1.13",
 	  "grunt": "~0.4.5",

--- a/teamcity.js
+++ b/teamcity.js
@@ -101,8 +101,8 @@ TSHintTeamcityFormatter.prototype = Object.create({
 			var lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
 			var item = {
 				reason: failure.getFailure(),
-				line: lineAndCharacter.line() + 1,
-				character: lineAndCharacter.character() + 1,
+				line: lineAndCharacter.line + 1,
+				character: lineAndCharacter.character + 1,
 				code: (failure.getRuleName ? failure.getRuleName() : '')
 			};
 			res.errors.push(item);

--- a/test/fixtures/files/output.txt
+++ b/test/fixtures/files/output.txt
@@ -29,6 +29,7 @@ Running "tslint:files" (tslint) task
 >> ##teamcity[testFailed name='(3,9) missing whitespace' message='|[whitespace|] missing whitespace' detailed='']
 >> ##teamcity[testFinished name='(3,9) missing whitespace']
 >> ##teamcity[testSuiteFinished name='TSLint: fixtures/files/failureB.test.ts']
+>> 8 errors in 2 files
 Warning: Task "tslint:files" failed. Use --force to continue.
 
 Aborted due to warnings.

--- a/test/fixtures/files/output.txt
+++ b/test/fixtures/files/output.txt
@@ -10,9 +10,6 @@ Running "tslint:files" (tslint) task
 >> ##teamcity[testStarted name='(5,3) missing semicolon']
 >> ##teamcity[testFailed name='(5,3) missing semicolon' message='|[semicolon|] missing semicolon' detailed='']
 >> ##teamcity[testFinished name='(5,3) missing semicolon']
->> ##teamcity[testStarted name='(6,1) missing whitespace']
->> ##teamcity[testFailed name='(6,1) missing whitespace' message='|[whitespace|] missing whitespace' detailed='']
->> ##teamcity[testFinished name='(6,1) missing whitespace']
 >> ##teamcity[testStarted name='(6,2) file should end with a newline']
 >> ##teamcity[testFailed name='(6,2) file should end with a newline' message='|[eofline|] file should end with a newline' detailed='']
 >> ##teamcity[testFinished name='(6,2) file should end with a newline']
@@ -22,14 +19,11 @@ Running "tslint:files" (tslint) task
 >> ##teamcity[testStarted name='(2,11) missing semicolon']
 >> ##teamcity[testFailed name='(2,11) missing semicolon' message='|[semicolon|] missing semicolon' detailed='']
 >> ##teamcity[testFinished name='(2,11) missing semicolon']
->> ##teamcity[testStarted name='(3,1) missing whitespace']
->> ##teamcity[testFailed name='(3,1) missing whitespace' message='|[whitespace|] missing whitespace' detailed='']
->> ##teamcity[testFinished name='(3,1) missing whitespace']
 >> ##teamcity[testStarted name='(3,9) missing whitespace']
 >> ##teamcity[testFailed name='(3,9) missing whitespace' message='|[whitespace|] missing whitespace' detailed='']
 >> ##teamcity[testFinished name='(3,9) missing whitespace']
 >> ##teamcity[testSuiteFinished name='TSLint: fixtures/files/failureB.test.ts']
->> 8 errors in 2 files
+>> 6 errors in 2 files
 Warning: Task "tslint:files" failed. Use --force to continue.
 
 Aborted due to warnings.


### PR DESCRIPTION
The latest version of the TSLint Teamcity Reporter has broken against the newest version of Grunt TSLint released recently due to an API change. This change should fix it. Includes minor API changes plus some dependency changes.
