### PR TITLE
Fix "inspection" formatter paths for TeamCity instances running on Windows

### DIFF
--- a/src/lib/formatters/inspections.ts
+++ b/src/lib/formatters/inspections.ts
@@ -26,7 +26,8 @@ export function formatAsInspections(failures: RuleFailure[], config: { [key: str
     );
 
     result.messages.forEach(failure => {
-      const filePath = path.relative(process.cwd(), failure.getFileName());
+      const relativeFilePath = path.relative(process.cwd(), failure.getFileName());
+      const filePath = relativeFilePath.replace(/\\/g, '/'); // Ensure slashes on Windows
       const startPos = failure.getStartPosition().getLineAndCharacter();
       const formattedMessage = `line ${startPos.line}, col ${
         startPos.character


### PR DESCRIPTION
A TeamCity instance running on Windows seems to require slash-separated paths instead of backslash, else the emitted file paths cannot be parsed. See the following before/after screenshot.

![image](https://user-images.githubusercontent.com/388796/54243107-775aef00-4527-11e9-8659-a190053fac95.png)

My TC version: 10.0.4.